### PR TITLE
declare module path as required by `go get`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module as
+module github.com/lunemec/as
 
 go 1.12


### PR DESCRIPTION
otherwise `go get` returns an error:

	module declares its path as: as
	        but was required as: github.com/lunemec/as